### PR TITLE
[Feat] JoinRoom(Before, After) ViewModel 적용 및 Network User 구현 및 API 연결 등

### DIFF
--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		9E4F309B2CC7D686009C59A4 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30912CC7D686009C59A4 /* Pretendard-Regular.otf */; };
 		9E4F309C2CC7D686009C59A4 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */; };
 		9E4F309D2CC7D686009C59A4 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */; };
-		9E648DD22CF73291004875B2 /* BeforeJoinRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */; };
+		9E648DD22CF73291004875B2 /* JoinRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD12CF73291004875B2 /* JoinRoomViewModel.swift */; };
 		9E648DD42CF73620004875B2 /* RoomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD32CF73620004875B2 /* RoomType.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
@@ -90,7 +90,7 @@
 		9E4F30912CC7D686009C59A4 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
-		9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeJoinRoomViewModel.swift; sourceTree = "<group>"; };
+		9E648DD12CF73291004875B2 /* JoinRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomViewModel.swift; sourceTree = "<group>"; };
 		9E648DD32CF73620004875B2 /* RoomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomType.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
@@ -351,7 +351,7 @@
 			isa = PBXGroup;
 			children = (
 				9E6FCB042CDABD3500D2A816 /* BeforeJoinRoomView.swift */,
-				9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */,
+				9E648DD12CF73291004875B2 /* JoinRoomViewModel.swift */,
 				9EB642542CE3850D00F7F156 /* SubViews */,
 			);
 			path = BeforeJoinRoom;
@@ -541,7 +541,7 @@
 				9EB642652CE542B600F7F156 /* NetworkResult.swift in Sources */,
 				9EB642582CE3C03C00F7F156 /* ActivityViewController.swift in Sources */,
 				9E4F30702CC7CE5F009C59A4 /* TheGreatestYourManito_iOSApp.swift in Sources */,
-				9E648DD22CF73291004875B2 /* BeforeJoinRoomViewModel.swift in Sources */,
+				9E648DD22CF73291004875B2 /* JoinRoomViewModel.swift in Sources */,
 				9EB6425D2CE4295C00F7F156 /* OpenManitoView.swift in Sources */,
 				88FEBFFC2CD3BA630013B9E1 /* PlayManittoResultView.swift in Sources */,
 				88A3564A2CCF728A005E2893 /* PlayManittoView.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		9E648DE12CF74F96004875B2 /* CheerTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE02CF74F96004875B2 /* CheerTargetType.swift */; };
 		9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE22CF74F9E004875B2 /* CheerService.swift */; };
 		9E648DE92CF7507A004875B2 /* UserIdentifyRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */; };
+		9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -106,6 +107,7 @@
 		9E648DE02CF74F96004875B2 /* CheerTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerTargetType.swift; sourceTree = "<group>"; };
 		9E648DE22CF74F9E004875B2 /* CheerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerService.swift; sourceTree = "<group>"; };
 		9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentifyRequestBody.swift; sourceTree = "<group>"; };
+		9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeUserRequestBody.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 			isa = PBXGroup;
 			children = (
 				9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */,
+				9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */,
 			);
 			path = RequestDTO;
 			sourceTree = "<group>";
@@ -610,6 +613,7 @@
 				9EB6425D2CE4295C00F7F156 /* OpenManitoView.swift in Sources */,
 				88FEBFFC2CD3BA630013B9E1 /* PlayManittoResultView.swift in Sources */,
 				88A3564A2CCF728A005E2893 /* PlayManittoView.swift in Sources */,
+				9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */,
 				9E648DD92CF74F18004875B2 /* UserService.swift in Sources */,
 				88A3564F2CCF9E1E005E2893 /* PlayManittoBottomView.swift in Sources */,
 				88A3565D2CCFB7CD005E2893 /* YMNavigationBar.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		9E4F309D2CC7D686009C59A4 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */; };
 		9E648DD22CF73291004875B2 /* JoinRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD12CF73291004875B2 /* JoinRoomViewModel.swift */; };
 		9E648DD42CF73620004875B2 /* RoomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD32CF73620004875B2 /* RoomType.swift */; };
+		9E648DD72CF74EA0004875B2 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD62CF74EA0004875B2 /* UserTargetType.swift */; };
+		9E648DD92CF74F18004875B2 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD82CF74F18004875B2 /* UserService.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -92,6 +94,8 @@
 		9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		9E648DD12CF73291004875B2 /* JoinRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinRoomViewModel.swift; sourceTree = "<group>"; };
 		9E648DD32CF73620004875B2 /* RoomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomType.swift; sourceTree = "<group>"; };
+		9E648DD62CF74EA0004875B2 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
+		9E648DD82CF74F18004875B2 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -231,6 +235,7 @@
 		9E4F307F2CC7CF5D009C59A4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				9E648DD52CF74E8E004875B2 /* User */,
 				9E4F30802CC7CFE8009C59A4 /* Base */,
 				9E4F30812CC7CFF8009C59A4 /* DTO */,
 				9E4F30822CC7D005009C59A4 /* Router */,
@@ -345,6 +350,15 @@
 				9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		9E648DD52CF74E8E004875B2 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				9E648DD62CF74EA0004875B2 /* UserTargetType.swift */,
+				9E648DD82CF74F18004875B2 /* UserService.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		9E6FCAFB2CDA7E4E00D2A816 /* BeforeJoinRoom */ = {
@@ -545,6 +559,7 @@
 				9EB6425D2CE4295C00F7F156 /* OpenManitoView.swift in Sources */,
 				88FEBFFC2CD3BA630013B9E1 /* PlayManittoResultView.swift in Sources */,
 				88A3564A2CCF728A005E2893 /* PlayManittoView.swift in Sources */,
+				9E648DD92CF74F18004875B2 /* UserService.swift in Sources */,
 				88A3564F2CCF9E1E005E2893 /* PlayManittoBottomView.swift in Sources */,
 				88A3565D2CCFB7CD005E2893 /* YMNavigationBar.swift in Sources */,
 				88A356562CCFB54F005E2893 /* View+.swift in Sources */,
@@ -557,6 +572,7 @@
 				9EB642672CE542DE00F7F156 /* NetworkService.swift in Sources */,
 				ED831DF72CCD506600486C5A /* RoomCardView.swift in Sources */,
 				88A3564D2CCF73FA005E2893 /* NameTagView.swift in Sources */,
+				9E648DD72CF74EA0004875B2 /* UserTargetType.swift in Sources */,
 				9EB642562CE3853500F7F156 /* BeforeJoinRoomBottomView.swift in Sources */,
 				9EB6426E2CE5473500F7F156 /* Development.xcconfig in Sources */,
 			);

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		9E648DF12CF75B82004875B2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF02CF75B82004875B2 /* Device.swift */; };
 		9E648DF32CF77583004875B2 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF22CF77583004875B2 /* IntroViewModel.swift */; };
 		9E648DF52CF779DB004875B2 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF42CF779DB004875B2 /* SignUpViewModel.swift */; };
+		9E648DF82CF7881B004875B2 /* UserCodeResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF72CF7881B004875B2 /* UserCodeResponseBody.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -128,6 +129,7 @@
 		9E648DF02CF75B82004875B2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		9E648DF22CF77583004875B2 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		9E648DF42CF779DB004875B2 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
+		9E648DF72CF7881B004875B2 /* UserCodeResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserCodeResponseBody.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -414,6 +416,7 @@
 			isa = PBXGroup;
 			children = (
 				9E648DE72CF75023004875B2 /* RequestDTO */,
+				9E648DF62CF787E5004875B2 /* ResponseDTO */,
 				9E648DD62CF74EA0004875B2 /* UserTargetType.swift */,
 				9E648DD82CF74F18004875B2 /* UserService.swift */,
 			);
@@ -445,6 +448,14 @@
 				9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */,
 			);
 			path = RequestDTO;
+			sourceTree = "<group>";
+		};
+		9E648DF62CF787E5004875B2 /* ResponseDTO */ = {
+			isa = PBXGroup;
+			children = (
+				9E648DF72CF7881B004875B2 /* UserCodeResponseBody.swift */,
+			);
+			path = ResponseDTO;
 			sourceTree = "<group>";
 		};
 		9E6FCAFB2CDA7E4E00D2A816 /* BeforeJoinRoom */ = {
@@ -627,6 +638,7 @@
 				88A356542CCFB24E005E2893 /* ManittoEventStatus.swift in Sources */,
 				9E4F30722CC7CE5F009C59A4 /* ContentView.swift in Sources */,
 				88A3565B2CCFB648005E2893 /* YMCapsuleLabel.swift in Sources */,
+				9E648DF82CF7881B004875B2 /* UserCodeResponseBody.swift in Sources */,
 				9EB811DF2CCFC497003C104D /* AfterJoinRoomBottomView.swift in Sources */,
 				9E648DD42CF73620004875B2 /* RoomType.swift in Sources */,
 				9EB811D82CCFBD64003C104D /* AfterJoinRoomView.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		9E4F309C2CC7D686009C59A4 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */; };
 		9E4F309D2CC7D686009C59A4 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */; };
 		9E648DD22CF73291004875B2 /* BeforeJoinRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */; };
+		9E648DD42CF73620004875B2 /* RoomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD32CF73620004875B2 /* RoomType.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -90,6 +91,7 @@
 		9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
 		9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeJoinRoomViewModel.swift; sourceTree = "<group>"; };
+		9E648DD32CF73620004875B2 /* RoomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomType.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 				88A356512CCFB062005E2893 /* CheerType.swift */,
 				88A356532CCFB24E005E2893 /* ManittoEventStatus.swift */,
 				9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */,
+				9E648DD32CF73620004875B2 /* RoomType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -522,6 +525,7 @@
 				9E4F30722CC7CE5F009C59A4 /* ContentView.swift in Sources */,
 				88A3565B2CCFB648005E2893 /* YMCapsuleLabel.swift in Sources */,
 				9EB811DF2CCFC497003C104D /* AfterJoinRoomBottomView.swift in Sources */,
+				9E648DD42CF73620004875B2 /* RoomType.swift in Sources */,
 				9EB811D82CCFBD64003C104D /* AfterJoinRoomView.swift in Sources */,
 				9EB811D02CCFB4BC003C104D /* YMJoinCodeStackView.swift in Sources */,
 				9EB642612CE5424E00F7F156 /* BaseTargetType.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		9E648DE92CF7507A004875B2 /* UserIdentifyRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */; };
 		9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */; };
 		9E648DEF2CF75868004875B2 /* BaseResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */; };
+		9E648DF12CF75B82004875B2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF02CF75B82004875B2 /* Device.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -110,6 +111,7 @@
 		9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentifyRequestBody.swift; sourceTree = "<group>"; };
 		9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeUserRequestBody.swift; sourceTree = "<group>"; };
 		9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseBody.swift; sourceTree = "<group>"; };
+		9E648DF02CF75B82004875B2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				88A356582CCFB57E005E2893 /* roundCorner.swift */,
+				9E648DF02CF75B82004875B2 /* Device.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				88A3565D2CCFB7CD005E2893 /* YMNavigationBar.swift in Sources */,
 				88A356562CCFB54F005E2893 /* View+.swift in Sources */,
 				88A356522CCFB062005E2893 /* CheerType.swift in Sources */,
+				9E648DF12CF75B82004875B2 /* Device.swift in Sources */,
 				9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */,
 				ED831DEF2CC8E1A100486C5A /* SignUpView.swift in Sources */,
 				9EB6426A2CE5437300F7F156 /* Config.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		9E648DDF2CF74F8D004875B2 /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DDE2CF74F8D004875B2 /* RoomService.swift */; };
 		9E648DE12CF74F96004875B2 /* CheerTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE02CF74F96004875B2 /* CheerTargetType.swift */; };
 		9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE22CF74F9E004875B2 /* CheerService.swift */; };
+		9E648DE92CF7507A004875B2 /* UserIdentifyRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -104,6 +105,7 @@
 		9E648DDE2CF74F8D004875B2 /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
 		9E648DE02CF74F96004875B2 /* CheerTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerTargetType.swift; sourceTree = "<group>"; };
 		9E648DE22CF74F9E004875B2 /* CheerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerService.swift; sourceTree = "<group>"; };
+		9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentifyRequestBody.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -365,6 +367,8 @@
 		9E648DD52CF74E8E004875B2 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				9E648DE72CF75023004875B2 /* RequestDTO */,
+				9E648DE62CF7501B004875B2 /* ResponseDTO */,
 				9E648DD62CF74EA0004875B2 /* UserTargetType.swift */,
 				9E648DD82CF74F18004875B2 /* UserService.swift */,
 			);
@@ -387,6 +391,21 @@
 				9E648DE22CF74F9E004875B2 /* CheerService.swift */,
 			);
 			path = Cheer;
+			sourceTree = "<group>";
+		};
+		9E648DE62CF7501B004875B2 /* ResponseDTO */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ResponseDTO;
+			sourceTree = "<group>";
+		};
+		9E648DE72CF75023004875B2 /* RequestDTO */ = {
+			isa = PBXGroup;
+			children = (
+				9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */,
+			);
+			path = RequestDTO;
 			sourceTree = "<group>";
 		};
 		9E6FCAFB2CDA7E4E00D2A816 /* BeforeJoinRoom */ = {
@@ -569,6 +588,7 @@
 				9EB811DF2CCFC497003C104D /* AfterJoinRoomBottomView.swift in Sources */,
 				9E648DD42CF73620004875B2 /* RoomType.swift in Sources */,
 				9EB811D82CCFBD64003C104D /* AfterJoinRoomView.swift in Sources */,
+				9E648DE92CF7507A004875B2 /* UserIdentifyRequestBody.swift in Sources */,
 				9EB811D02CCFB4BC003C104D /* YMJoinCodeStackView.swift in Sources */,
 				9EB642612CE5424E00F7F156 /* BaseTargetType.swift in Sources */,
 				9EB811E12CD0CA31003C104D /* JoinMemberModel.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		9E648DEF2CF75868004875B2 /* BaseResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */; };
 		9E648DF12CF75B82004875B2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF02CF75B82004875B2 /* Device.swift */; };
 		9E648DF32CF77583004875B2 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF22CF77583004875B2 /* IntroViewModel.swift */; };
+		9E648DF52CF779DB004875B2 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF42CF779DB004875B2 /* SignUpViewModel.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -126,6 +127,7 @@
 		9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseBody.swift; sourceTree = "<group>"; };
 		9E648DF02CF75B82004875B2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		9E648DF22CF77583004875B2 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
+		9E648DF42CF779DB004875B2 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 			isa = PBXGroup;
 			children = (
 				ED831DEE2CC8E1A100486C5A /* SignUpView.swift */,
+				9E648DF42CF779DB004875B2 /* SignUpViewModel.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -638,6 +641,7 @@
 				9EB6425A2CE3E77D00F7F156 /* YMLoadingView.swift in Sources */,
 				9E4F308A2CC7D484009C59A4 /* Font+.swift in Sources */,
 				9E6FCB052CDABD3500D2A816 /* BeforeJoinRoomView.swift in Sources */,
+				9E648DF52CF779DB004875B2 /* SignUpViewModel.swift in Sources */,
 				9EB642632CE5428700F7F156 /* MoyaLoggingPlugin.swift in Sources */,
 				9E648DDD2CF74F82004875B2 /* RoomTargetType.swift in Sources */,
 				9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */; };
 		9E648DEF2CF75868004875B2 /* BaseResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */; };
 		9E648DF12CF75B82004875B2 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF02CF75B82004875B2 /* Device.swift */; };
+		9E648DF32CF77583004875B2 /* IntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DF22CF77583004875B2 /* IntroViewModel.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -124,6 +125,7 @@
 		9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeUserRequestBody.swift; sourceTree = "<group>"; };
 		9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseBody.swift; sourceTree = "<group>"; };
 		9E648DF02CF75B82004875B2 /* Device.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		9E648DF22CF77583004875B2 /* IntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewModel.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 			isa = PBXGroup;
 			children = (
 				ED831DF12CC8E1EE00486C5A /* IntroView.swift */,
+				9E648DF22CF77583004875B2 /* IntroViewModel.swift */,
 			);
 			path = Intro;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				8832C3722CDF28CB00B8DFAB /* ManiitoRank.swift in Sources */,
 				9EB642672CE542DE00F7F156 /* NetworkService.swift in Sources */,
 				ED831DF72CCD506600486C5A /* RoomCardView.swift in Sources */,
+				9E648DF32CF77583004875B2 /* IntroViewModel.swift in Sources */,
 				9E648DD72CF74EA0004875B2 /* UserTargetType.swift in Sources */,
 				9EB642562CE3853500F7F156 /* BeforeJoinRoomBottomView.swift in Sources */,
 				9E648DDF2CF74F8D004875B2 /* RoomService.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE22CF74F9E004875B2 /* CheerService.swift */; };
 		9E648DE92CF7507A004875B2 /* UserIdentifyRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */; };
 		9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */; };
+		9E648DEF2CF75868004875B2 /* BaseResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -108,6 +109,7 @@
 		9E648DE22CF74F9E004875B2 /* CheerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerService.swift; sourceTree = "<group>"; };
 		9E648DE82CF75050004875B2 /* UserIdentifyRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdentifyRequestBody.swift; sourceTree = "<group>"; };
 		9E648DEA2CF754E5004875B2 /* MakeUserRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeUserRequestBody.swift; sourceTree = "<group>"; };
+		9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponseBody.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 				9EB642622CE5428700F7F156 /* MoyaLoggingPlugin.swift */,
 				9EB642642CE542B600F7F156 /* NetworkResult.swift */,
 				9EB642662CE542DE00F7F156 /* NetworkService.swift */,
+				9E648DEE2CF75868004875B2 /* BaseResponseBody.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -370,7 +373,6 @@
 			isa = PBXGroup;
 			children = (
 				9E648DE72CF75023004875B2 /* RequestDTO */,
-				9E648DE62CF7501B004875B2 /* ResponseDTO */,
 				9E648DD62CF74EA0004875B2 /* UserTargetType.swift */,
 				9E648DD82CF74F18004875B2 /* UserService.swift */,
 			);
@@ -393,13 +395,6 @@
 				9E648DE22CF74F9E004875B2 /* CheerService.swift */,
 			);
 			path = Cheer;
-			sourceTree = "<group>";
-		};
-		9E648DE62CF7501B004875B2 /* ResponseDTO */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ResponseDTO;
 			sourceTree = "<group>";
 		};
 		9E648DE72CF75023004875B2 /* RequestDTO */ = {
@@ -613,6 +608,7 @@
 				9EB6425D2CE4295C00F7F156 /* OpenManitoView.swift in Sources */,
 				88FEBFFC2CD3BA630013B9E1 /* PlayManittoResultView.swift in Sources */,
 				88A3564A2CCF728A005E2893 /* PlayManittoView.swift in Sources */,
+				9E648DEF2CF75868004875B2 /* BaseResponseBody.swift in Sources */,
 				9E648DEB2CF754E5004875B2 /* MakeUserRequestBody.swift in Sources */,
 				9E648DD92CF74F18004875B2 /* UserService.swift in Sources */,
 				88A3564F2CCF9E1E005E2893 /* PlayManittoBottomView.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9E4F309B2CC7D686009C59A4 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30912CC7D686009C59A4 /* Pretendard-Regular.otf */; };
 		9E4F309C2CC7D686009C59A4 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */; };
 		9E4F309D2CC7D686009C59A4 /* Pretendard-Thin.otf in Resources */ = {isa = PBXBuildFile; fileRef = 9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */; };
+		9E648DD22CF73291004875B2 /* BeforeJoinRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -88,6 +89,7 @@
 		9E4F30912CC7D686009C59A4 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		9E4F30922CC7D686009C59A4 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
 		9E4F30932CC7D686009C59A4 /* Pretendard-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Thin.otf"; sourceTree = "<group>"; };
+		9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeJoinRoomViewModel.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				9E6FCB042CDABD3500D2A816 /* BeforeJoinRoomView.swift */,
+				9E648DD12CF73291004875B2 /* BeforeJoinRoomViewModel.swift */,
 				9EB642542CE3850D00F7F156 /* SubViews */,
 			);
 			path = BeforeJoinRoom;
@@ -534,6 +537,7 @@
 				9EB642652CE542B600F7F156 /* NetworkResult.swift in Sources */,
 				9EB642582CE3C03C00F7F156 /* ActivityViewController.swift in Sources */,
 				9E4F30702CC7CE5F009C59A4 /* TheGreatestYourManito_iOSApp.swift in Sources */,
+				9E648DD22CF73291004875B2 /* BeforeJoinRoomViewModel.swift in Sources */,
 				9EB6425D2CE4295C00F7F156 /* OpenManitoView.swift in Sources */,
 				88FEBFFC2CD3BA630013B9E1 /* PlayManittoResultView.swift in Sources */,
 				88A3564A2CCF728A005E2893 /* PlayManittoView.swift in Sources */,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS.xcodeproj/project.pbxproj
@@ -36,6 +36,10 @@
 		9E648DD42CF73620004875B2 /* RoomType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD32CF73620004875B2 /* RoomType.swift */; };
 		9E648DD72CF74EA0004875B2 /* UserTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD62CF74EA0004875B2 /* UserTargetType.swift */; };
 		9E648DD92CF74F18004875B2 /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DD82CF74F18004875B2 /* UserService.swift */; };
+		9E648DDD2CF74F82004875B2 /* RoomTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DDC2CF74F82004875B2 /* RoomTargetType.swift */; };
+		9E648DDF2CF74F8D004875B2 /* RoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DDE2CF74F8D004875B2 /* RoomService.swift */; };
+		9E648DE12CF74F96004875B2 /* CheerTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE02CF74F96004875B2 /* CheerTargetType.swift */; };
+		9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E648DE22CF74F9E004875B2 /* CheerService.swift */; };
 		9E6699752CD368A50053960A /* YMBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699742CD368A50053960A /* YMBottomSheet.swift */; };
 		9E6699772CD3CF4D0053960A /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699762CD3CF4D0053960A /* StringLiterals.swift */; };
 		9E6699792CD3EE7D0053960A /* BottomSheetContentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */; };
@@ -96,6 +100,10 @@
 		9E648DD32CF73620004875B2 /* RoomType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomType.swift; sourceTree = "<group>"; };
 		9E648DD62CF74EA0004875B2 /* UserTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTargetType.swift; sourceTree = "<group>"; };
 		9E648DD82CF74F18004875B2 /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
+		9E648DDC2CF74F82004875B2 /* RoomTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomTargetType.swift; sourceTree = "<group>"; };
+		9E648DDE2CF74F8D004875B2 /* RoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomService.swift; sourceTree = "<group>"; };
+		9E648DE02CF74F96004875B2 /* CheerTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerTargetType.swift; sourceTree = "<group>"; };
+		9E648DE22CF74F9E004875B2 /* CheerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheerService.swift; sourceTree = "<group>"; };
 		9E6699742CD368A50053960A /* YMBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YMBottomSheet.swift; sourceTree = "<group>"; };
 		9E6699762CD3CF4D0053960A /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		9E6699782CD3EE7D0053960A /* BottomSheetContentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetContentType.swift; sourceTree = "<group>"; };
@@ -236,6 +244,8 @@
 			isa = PBXGroup;
 			children = (
 				9E648DD52CF74E8E004875B2 /* User */,
+				9E648DDA2CF74F66004875B2 /* Room */,
+				9E648DDB2CF74F6B004875B2 /* Cheer */,
 				9E4F30802CC7CFE8009C59A4 /* Base */,
 				9E4F30812CC7CFF8009C59A4 /* DTO */,
 				9E4F30822CC7D005009C59A4 /* Router */,
@@ -359,6 +369,24 @@
 				9E648DD82CF74F18004875B2 /* UserService.swift */,
 			);
 			path = User;
+			sourceTree = "<group>";
+		};
+		9E648DDA2CF74F66004875B2 /* Room */ = {
+			isa = PBXGroup;
+			children = (
+				9E648DDC2CF74F82004875B2 /* RoomTargetType.swift */,
+				9E648DDE2CF74F8D004875B2 /* RoomService.swift */,
+			);
+			path = Room;
+			sourceTree = "<group>";
+		};
+		9E648DDB2CF74F6B004875B2 /* Cheer */ = {
+			isa = PBXGroup;
+			children = (
+				9E648DE02CF74F96004875B2 /* CheerTargetType.swift */,
+				9E648DE22CF74F9E004875B2 /* CheerService.swift */,
+			);
+			path = Cheer;
 			sourceTree = "<group>";
 		};
 		9E6FCAFB2CDA7E4E00D2A816 /* BeforeJoinRoom */ = {
@@ -551,6 +579,9 @@
 				9E4F308A2CC7D484009C59A4 /* Font+.swift in Sources */,
 				9E6FCB052CDABD3500D2A816 /* BeforeJoinRoomView.swift in Sources */,
 				9EB642632CE5428700F7F156 /* MoyaLoggingPlugin.swift in Sources */,
+				9E648DDD2CF74F82004875B2 /* RoomTargetType.swift in Sources */,
+				9E648DE32CF74F9E004875B2 /* CheerService.swift in Sources */,
+				9E648DE12CF74F96004875B2 /* CheerTargetType.swift in Sources */,
 				88A3565F2CCFC005005E2893 /* PlayManittoViewModel.swift in Sources */,
 				9EB642652CE542B600F7F156 /* NetworkResult.swift in Sources */,
 				9EB642582CE3C03C00F7F156 /* ActivityViewController.swift in Sources */,
@@ -574,6 +605,7 @@
 				88A3564D2CCF73FA005E2893 /* NameTagView.swift in Sources */,
 				9E648DD72CF74EA0004875B2 /* UserTargetType.swift in Sources */,
 				9EB642562CE3853500F7F156 /* BeforeJoinRoomBottomView.swift in Sources */,
+				9E648DDF2CF74F8D004875B2 /* RoomService.swift in Sources */,
 				9EB6426E2CE5473500F7F156 /* Development.xcconfig in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/RoomType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/RoomType.swift
@@ -5,4 +5,9 @@
 //  Created by 박신영 on 11/27/24.
 //
 
-import Foundation
+import SwiftUI
+
+enum RoomType {
+    case owner
+    case notOwner
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/RoomType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/RoomType.swift
@@ -1,0 +1,8 @@
+//
+//  RoomType.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Utility/Device.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Utility/Device.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct Device {
     
     func getDeviceUUID() -> String {
-        return UIDevice.current.identifierForVendor!.uuidString
+        let deviceId = UIDevice.current.identifierForVendor!.uuidString
+        UserDefaults.standard.set(deviceId, forKey: "deviceId")
+        return deviceId
     }
     
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Utility/Device.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Utility/Device.swift
@@ -1,0 +1,16 @@
+//
+//  Device.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import SwiftUI
+
+struct Device {
+    
+    func getDeviceUUID() -> String {
+        return UIDevice.current.identifierForVendor!.uuidString
+    }
+    
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-struct BaseResponseBody: Decodable {
+struct BaseResponseBody: Codable {
     let isSuccess: Bool
     let code: Int
     let message: String
     let result: BaseResponseResult?
 }
 
-struct BaseResponseResult: Decodable {
+struct BaseResponseResult: Codable {
     let userCode: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
@@ -16,6 +16,4 @@ struct BaseResponseBody<T: Decodable>: Decodable {
 
 struct emptyResponse: Decodable {}
 
-struct userCodeResponse: Decodable {
-    let userCode: String
-}
+

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
@@ -1,0 +1,19 @@
+//
+//  BaseResponseBody.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation
+
+struct BaseResponseBody: Decodable {
+    let isSuccess: Bool
+    let code: Int
+    let message: String
+    let result: BaseResponseResult?
+}
+
+struct BaseResponseResult: Decodable {
+    let userCode: String
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-struct BaseResponseBody: Codable {
+struct BaseResponseBody: Decodable {
     let isSuccess: Bool
     let code: Int
     let message: String
     let result: BaseResponseResult?
 }
 
-struct BaseResponseResult: Codable {
+struct BaseResponseResult: Decodable {
     let userCode: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseResponseBody.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 
-struct BaseResponseBody: Decodable {
+struct BaseResponseBody<T: Decodable>: Decodable {
     let isSuccess: Bool
     let code: Int
     let message: String
-    let result: BaseResponseResult?
+    let result: T?
 }
 
-struct BaseResponseResult: Decodable {
+struct emptyResponse: Decodable {}
+
+struct userCodeResponse: Decodable {
     let userCode: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseService.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class BaseService {
-   func judgeStatus<T: Codable>(statusCode: Int, data: Data) -> NetworkResult<T> {
+    func judgeStatus<T: Decodable>(statusCode: Int, data: Data) -> NetworkResult<T> {
       switch statusCode {
       case 200..<205:
          return isValidData(data: data, responseType: T.self)
@@ -21,7 +21,7 @@ class BaseService {
       }
    }
    
-   func isValidData<T: Codable>(data: Data, responseType: T.Type) -> NetworkResult<T> {
+    func isValidData<T: Decodable>(data: Data, responseType: T.Type) -> NetworkResult<T> {
       let decoder = JSONDecoder()
       guard let decodedData = try? decoder.decode(T.self, from: data) else {
          print("⛔️ \(self)애서 디코딩 오류가 발생했습니다 ⛔️")

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkService.swift
@@ -8,11 +8,12 @@
 import Foundation
 
 final class NetworkService {
-   
-   static let shared = NetworkService()
-   
-   private init() {}
-   
+    
+    static let shared = NetworkService()
+    
+    private init() {}
+    
+    let userService: UserService = UserService()
     // ex
     // let openManitoService: OpenManitoService = OpenManitoService()
     

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkService.swift
@@ -13,7 +13,7 @@ final class NetworkService {
     
     private init() {}
     
-    let userService: UserService = UserService()
+    let userService: UserServiceProtocol = UserService.shared
     // ex
     // let openManitoService: OpenManitoService = OpenManitoService()
     

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Cheer/CheerService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Cheer/CheerService.swift
@@ -1,0 +1,8 @@
+//
+//  CheerService.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Cheer/CheerTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Cheer/CheerTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  CheerTargetType.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/RoomService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/RoomService.swift
@@ -1,0 +1,8 @@
+//
+//  RoomService.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/RoomTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/RoomTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  RoomTargetType.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+struct MakeUserRequestBody: Codable {
+    let nickname: String
+    let deviceId: String
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
@@ -1,0 +1,8 @@
+//
+//  MakeUserRequestBody.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/MakeUserRequestBody.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MakeUserRequestBody: Codable {
+struct MakeUserRequestBody: Encodable {
     let nickname: String
     let deviceId: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct UserIdentifyRequestBody: Codable {
+struct UserIdentifyRequestBody: Encodable {
     let deviceId: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
@@ -1,0 +1,12 @@
+//
+//  UserIdentifyRequestBody.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation
+
+struct UserIdentifyRequestBody {
+    let deviceId: String
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/RequestDTO/UserIdentifyRequestBody.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct UserIdentifyRequestBody {
+struct UserIdentifyRequestBody: Codable {
     let deviceId: String
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/ResponseDTO/UserCodeResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/ResponseDTO/UserCodeResponseBody.swift
@@ -1,0 +1,12 @@
+//
+//  UserCodeResponseBody.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/28/24.
+//
+
+import Foundation
+
+struct userCodeResponse: Decodable {
+    let userCode: String
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -11,9 +11,9 @@ import Moya
 
 protocol UserServiceProtocol {
     
-    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ())
+    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody<emptyResponse>>) -> ())
     
-    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ())
+    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody<userCodeResponse>>) -> ())
     
 }
 
@@ -25,11 +25,11 @@ final class UserService: BaseService, UserServiceProtocol {
     
     let provider = MoyaProvider<UserTargetType>(plugins: [MoyaLoggingPlugin()])
     
-    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
+    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody<emptyResponse>>) -> ()) {
         provider.request(.postUserIdentify(requestBody: requestBody)) { result in
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<BaseResponseBody> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<BaseResponseBody<emptyResponse>> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
                 completion(networkResult)
             case .failure(let err):
                 print(err)
@@ -37,11 +37,11 @@ final class UserService: BaseService, UserServiceProtocol {
         }
     }
     
-    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
+    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody<userCodeResponse>>) -> ()) {
         provider.request(.postMakeUser(requestBody: requestBody)) { result in
             switch result {
             case .success(let response):
-                let networkResult: NetworkResult<BaseResponseBody> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                let networkResult: NetworkResult<BaseResponseBody<userCodeResponse>> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
                 completion(networkResult)
             case .failure(let err):
                 print(err)

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -19,6 +19,10 @@ protocol UserServiceProtocol {
 
 final class UserService: BaseService, UserServiceProtocol {
     
+    override private init() {}
+    
+    static let shared = UserService()
+    
     let provider = MoyaProvider<UserTargetType>(plugins: [MoyaLoggingPlugin()])
     
     func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
@@ -46,24 +50,3 @@ final class UserService: BaseService, UserServiceProtocol {
     }
     
 }
-
-//MARK: - PostMakeUser
-/// 1. postMakeUser 사용할 때에 아래 함수 해당 뷰 ViewModel에 추가
-/// 2. 위 ViewModel의 View에 .onappear 코드 사용
-
-/*
-//PostMakeUser
-
- 
-...
- 
-.onAppear(perform: {
-   (뷰 모델 변수명).postMakeUser()
-})
-*/
-
-
-//MARK: - PostUserIdentify
-/**
-
- */

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -11,7 +11,7 @@ import Moya
 
 protocol UserServiceProtocol {
     
-//    func postUserIdentify(completion: @escaping (NetworkResult<GetUserProfileResponse>) -> ())
+    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ())
     
     func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ())
     
@@ -20,6 +20,18 @@ protocol UserServiceProtocol {
 final class UserService: BaseService, UserServiceProtocol {
     
     let provider = MoyaProvider<UserTargetType>(plugins: [MoyaLoggingPlugin()])
+    
+    func postUserIdentify(requestBody: UserIdentifyRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
+        provider.request(.postUserIdentify(requestBody: requestBody)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<BaseResponseBody> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
     
     func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
         provider.request(.postMakeUser(requestBody: requestBody)) { result in
@@ -35,15 +47,14 @@ final class UserService: BaseService, UserServiceProtocol {
     
 }
 
-
+//MARK: - PostMakeUser
 /// 1. postMakeUser 사용할 때에 아래 함수 해당 뷰 ViewModel에 추가
 /// 2. 위 ViewModel의 View에 .onappear 코드 사용
 
 /*
- 1.
+//PostMakeUser
 func postMakeUser() {
-    let device = Device()
-    let udid = device.getDeviceUUID()
+ guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}
     
     let requestBody = MakeUserRequestBody(nickname: "psy", deviceId: udid)
     NetworkService.shared.userService.postMakeUser(requestBody: requestBody, completion: { result in
@@ -56,9 +67,30 @@ func postMakeUser() {
         }
     })
 }
-
- 2.
+ 
+...
+ 
 .onAppear(perform: {
    (뷰 모델 변수명).postMakeUser()
 })
 */
+
+
+//MARK: - PostUserIdentify
+/**
+func postUserIdentify() {
+ let device = Device()
+ let udid = device.getDeviceUUID()
+ guard let userDefaults = UserDefaults.standard.string(forKey: "deviceId") else {return}
+ let requestBody = UserIdentifyRequestBody(deviceId: userDefaults)
+ NetworkService.shared.userService.postUserIdentify(requestBody: requestBody, completion: { result in
+     switch result {
+     case .success(let response):
+         print("Success: \(response)")
+     default:
+         print("Failed to another reason")
+         return
+     }
+ })
+}
+ */

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -6,3 +6,59 @@
 //
 
 import Foundation
+
+import Moya
+
+protocol UserServiceProtocol {
+    
+//    func postUserIdentify(completion: @escaping (NetworkResult<GetUserProfileResponse>) -> ())
+    
+    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ())
+    
+}
+
+final class UserService: BaseService, UserServiceProtocol {
+    
+    let provider = MoyaProvider<UserTargetType>(plugins: [MoyaLoggingPlugin()])
+    
+    func postMakeUser(requestBody: MakeUserRequestBody, completion: @escaping (NetworkResult<BaseResponseBody>) -> ()) {
+        provider.request(.postMakeUser(requestBody: requestBody)) { result in
+            switch result {
+            case .success(let response):
+                let networkResult: NetworkResult<BaseResponseBody> = self.judgeStatus(statusCode: response.statusCode, data: response.data)
+                completion(networkResult)
+            case .failure(let err):
+                print(err)
+            }
+        }
+    }
+    
+}
+
+
+/// 1. postMakeUser 사용할 때에 아래 함수 해당 뷰 ViewModel에 추가
+/// 2. 위 ViewModel의 View에 .onappear 코드 사용
+
+/*
+ 1.
+func postMakeUser() {
+    let device = Device()
+    let udid = device.getDeviceUUID()
+    
+    let requestBody = MakeUserRequestBody(nickname: "psy", deviceId: udid)
+    NetworkService.shared.userService.postMakeUser(requestBody: requestBody, completion: { result in
+        switch result {
+        case .success(let response):
+            print("Success: \(response)")
+        default:
+            print("Failed to another reason")
+            return
+        }
+    })
+}
+
+ 2.
+.onAppear(perform: {
+   (뷰 모델 변수명).postMakeUser()
+})
+*/

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -53,20 +53,7 @@ final class UserService: BaseService, UserServiceProtocol {
 
 /*
 //PostMakeUser
-func postMakeUser() {
- guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}
-    
-    let requestBody = MakeUserRequestBody(nickname: "psy", deviceId: udid)
-    NetworkService.shared.userService.postMakeUser(requestBody: requestBody, completion: { result in
-        switch result {
-        case .success(let response):
-            print("Success: \(response)")
-        default:
-            print("Failed to another reason")
-            return
-        }
-    })
-}
+
  
 ...
  
@@ -78,19 +65,5 @@ func postMakeUser() {
 
 //MARK: - PostUserIdentify
 /**
-func postUserIdentify() {
- let device = Device()
- let udid = device.getDeviceUUID()
- guard let userDefaults = UserDefaults.standard.string(forKey: "deviceId") else {return}
- let requestBody = UserIdentifyRequestBody(deviceId: userDefaults)
- NetworkService.shared.userService.postUserIdentify(requestBody: requestBody, completion: { result in
-     switch result {
-     case .success(let response):
-         print("Success: \(response)")
-     default:
-         print("Failed to another reason")
-         return
-     }
- })
-}
+
  */

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserService.swift
@@ -1,0 +1,8 @@
+//
+//  UserService.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
@@ -6,3 +6,44 @@
 //
 
 import Foundation
+
+import Moya
+
+enum UserTargetType {
+    
+    case postUserIdentify(requestBody: UserIdentifyRequestBody)
+    
+}
+
+extension UserTargetType: BaseTargetType {
+    
+    var method: Moya.Method {
+        switch self {
+        case .postUserIdentify:
+            return .post
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .postUserIdentify:
+            return "/user/identify"
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .postUserIdentify(let requestBody):
+            return .requestJSONEncodable(requestBody)
+        }
+    }
+    
+    var headers: [String : String]? {
+        
+        switch self {
+        default:
+            return nil
+        }
+    }
+    
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
@@ -43,12 +43,4 @@ extension UserTargetType: BaseTargetType {
         }
     }
     
-    var headers: [String : String]? {
-        
-        switch self {
-        default:
-            return nil
-        }
-    }
-    
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
@@ -12,6 +12,7 @@ import Moya
 enum UserTargetType {
     
     case postUserIdentify(requestBody: UserIdentifyRequestBody)
+    case postMakeUser(requestBody: MakeUserRequestBody)
     
 }
 
@@ -19,7 +20,7 @@ extension UserTargetType: BaseTargetType {
     
     var method: Moya.Method {
         switch self {
-        case .postUserIdentify:
+        case .postUserIdentify, .postMakeUser:
             return .post
         }
     }
@@ -28,12 +29,16 @@ extension UserTargetType: BaseTargetType {
         switch self {
         case .postUserIdentify:
             return "/user/identify"
+        case .postMakeUser:
+            return "/user"
         }
     }
     
     var task: Task {
         switch self {
         case .postUserIdentify(let requestBody):
+            return .requestJSONEncodable(requestBody)
+        case .postMakeUser(let requestBody):
             return .requestJSONEncodable(requestBody)
         }
     }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/User/UserTargetType.swift
@@ -1,0 +1,8 @@
+//
+//  UserTargetType.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
@@ -12,13 +12,14 @@ import SwiftUI
 struct AfterJoinRoomView: View {
     
     @Environment(\.dismiss) private var dismiss
-    @State var roomName: String
-    @State var memberCount: Int
-    @State var memberListModel: [JoinMemberModel]
+    @EnvironmentObject var viewModel: JoinRoomViewModel
+//    @State var roomName: String
+//    @State var memberCount: Int
+//    @State var memberListModel: [JoinMemberModel]
     @State private var isCopyOnClipBoard: Bool = false
     @State private var isShowingShareSheet: Bool = false
     @Binding var joinCode: String
-    let roomType: RoomType
+//    let roomType: RoomType
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -46,7 +47,7 @@ struct AfterJoinRoomView: View {
         VStack(spacing: 21) {
             VStack {
                 HStack {
-                    Text(roomName)
+                    Text(viewModel.roomName)
                         .font(.pretendardFont(for: .heading2))
                         .foregroundColor(.ymBlack)
                     Spacer()
@@ -58,7 +59,8 @@ struct AfterJoinRoomView: View {
     }
     
     private var bottomView: some View {
-        AfterJoinRoomBottomView(memberCount: $memberCount, memberListModel: $memberListModel, isCopyOnClipBoard: $isCopyOnClipBoard, roomType: roomType)
+        AfterJoinRoomBottomView(isCopyOnClipBoard: $isCopyOnClipBoard)
+            .environmentObject(viewModel)
     }
     
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
@@ -7,19 +7,13 @@
 
 import SwiftUI
 
-
-
 struct AfterJoinRoomView: View {
     
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var viewModel: JoinRoomViewModel
-//    @State var roomName: String
-//    @State var memberCount: Int
-//    @State var memberListModel: [JoinMemberModel]
     @State private var isCopyOnClipBoard: Bool = false
     @State private var isShowingShareSheet: Bool = false
     @Binding var joinCode: String
-//    let roomType: RoomType
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -64,11 +58,6 @@ struct AfterJoinRoomView: View {
     }
     
 }
-
-
-//#Preview {
-//    AfterJoinRoomView(roomName: "ㄴㄴㄴ", joinCode: "~~~~~~~~~", memberCount: 1, memberListModel: [JoinMemberModel(memberName: "하세요2"), JoinMemberModel(memberName: "하세요1"), JoinMemberModel(memberName: "하세요"), JoinMemberModel(memberName: "하세요"),JoinMemberModel(memberName: "하세요4")], roomType: .owner)
-//}
 
 
 

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/AfterJoinRoomView.swift
@@ -7,10 +7,7 @@
 
 import SwiftUI
 
-enum RoomType {
-    case owner
-    case notOwner
-}
+
 
 struct AfterJoinRoomView: View {
     

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/SubViews/AfterJoinRoomBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/SubViews/AfterJoinRoomBottomView.swift
@@ -8,24 +8,25 @@
 import SwiftUI
 
 struct AfterJoinRoomBottomView: View {
-    @Binding var memberCount: Int
-    @Binding var memberListModel: [JoinMemberModel]
+//    @Binding var memberCount: Int
+//    @Binding var memberListModel: [JoinMemberModel]
+    @EnvironmentObject var viewModel: JoinRoomViewModel
     @Binding var isCopyOnClipBoard: Bool
     @State private var showDeleteSheet = false
     @State private var showSheet = false
-    let roomType: RoomType
+//    let roomType: RoomType
     
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                MemberCountLabelView(memberCount: $memberCount, roomType: roomType)
+                MemberCountLabelView()
                 Spacer()
             }
             .padding(.top, 40)
             
             VStack(spacing: 18) {
-                MemberListScrollView(memberListModel: $memberListModel, showDeleteSheet: $showDeleteSheet, roomType: roomType)
-                if case .owner = roomType {
+                MemberListScrollView(showDeleteSheet: $showDeleteSheet)
+                if case .owner = viewModel.roomType {
                     Spacer(minLength: 20)
                     confirmButton()
                 }
@@ -48,6 +49,7 @@ struct AfterJoinRoomBottomView: View {
             .animation(.easeOut(duration: 0.3), value: isCopyOnClipBoard)
             Spacer(minLength: 20)
         }
+        .environmentObject(viewModel)
         .frame(height: 495)
         .background(.ymWhite)
         .padding(.bottom, 25)
@@ -71,16 +73,16 @@ struct AfterJoinRoomBottomView: View {
 }
 
 struct MemberCountLabelView: View {
-    
-    @Binding var memberCount: Int
-    let roomType: RoomType
+    @EnvironmentObject var viewModel: JoinRoomViewModel
+//    @Binding var memberCount: Int
+//    let roomType: RoomType
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("총 \(memberCount)명")
+            Text("총 \(viewModel.memberCount)명")
                 .font(.pretendardFont(for: .heading4))
                 .foregroundStyle(.ymBlack)
-            if case .owner = roomType {
+            if case .owner = viewModel.roomType {
                 Text(StringLiterals.AfterJoinRoom.ownerNoticeWordLabel)
                     .font(.pretendardFont(for: .subtitle1))
                     .foregroundStyle(.gray1)
@@ -96,15 +98,17 @@ struct MemberCountLabelView: View {
 }
 
 struct MemberListScrollView: View {
-    @Binding var memberListModel: [JoinMemberModel]
+    @EnvironmentObject var viewModel: JoinRoomViewModel
+//    @Binding var memberListModel: [JoinMemberModel]
     @Binding var showDeleteSheet: Bool
-    let roomType: RoomType
+//    let roomType: RoomType
     
     var body: some View {
         ScrollView {
             VStack(spacing: 16) {
-                ForEach(memberListModel, id: \.memberName) { member in
-                    MemberListItemView(member: member, showDeleteSheet: $showDeleteSheet, roomType: roomType)
+                ForEach(viewModel.memberListModel, id: \.memberName) { member in
+                    MemberListItemView(member: member, showDeleteSheet: $showDeleteSheet)
+                        .environmentObject(viewModel)
                 }
             }
             .padding(.horizontal, 24)
@@ -116,7 +120,8 @@ struct MemberListScrollView: View {
 struct MemberListItemView: View {
     let member: JoinMemberModel
     @Binding var showDeleteSheet: Bool
-    let roomType: RoomType
+//    let roomType: RoomType
+    @EnvironmentObject var viewModel: JoinRoomViewModel
     
     var body: some View {
         ZStack {
@@ -130,7 +135,7 @@ struct MemberListItemView: View {
                     .font(.pretendardFont(for: .heading5))
                     .foregroundStyle(.ymBlack)
                 Spacer()
-                if case .owner = roomType {
+                if case .owner = viewModel.roomType {
                     ymCircleDeleteButton()
                 }
             }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/SubViews/AfterJoinRoomBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/AfterJoinRoom/SubViews/AfterJoinRoomBottomView.swift
@@ -8,13 +8,11 @@
 import SwiftUI
 
 struct AfterJoinRoomBottomView: View {
-//    @Binding var memberCount: Int
-//    @Binding var memberListModel: [JoinMemberModel]
+    
     @EnvironmentObject var viewModel: JoinRoomViewModel
     @Binding var isCopyOnClipBoard: Bool
     @State private var showDeleteSheet = false
     @State private var showSheet = false
-//    let roomType: RoomType
     
     var body: some View {
         VStack(spacing: 0) {
@@ -30,7 +28,6 @@ struct AfterJoinRoomBottomView: View {
                     Spacer(minLength: 20)
                     confirmButton()
                 }
-                
             }
             .padding(.top, 18)
             .overlay(
@@ -73,9 +70,8 @@ struct AfterJoinRoomBottomView: View {
 }
 
 struct MemberCountLabelView: View {
+    
     @EnvironmentObject var viewModel: JoinRoomViewModel
-//    @Binding var memberCount: Int
-//    let roomType: RoomType
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -98,10 +94,9 @@ struct MemberCountLabelView: View {
 }
 
 struct MemberListScrollView: View {
+    
     @EnvironmentObject var viewModel: JoinRoomViewModel
-//    @Binding var memberListModel: [JoinMemberModel]
     @Binding var showDeleteSheet: Bool
-//    let roomType: RoomType
     
     var body: some View {
         ScrollView {
@@ -115,12 +110,13 @@ struct MemberListScrollView: View {
         }
         .frame(maxHeight: 280)
     }
+    
 }
 
 struct MemberListItemView: View {
+    
     let member: JoinMemberModel
     @Binding var showDeleteSheet: Bool
-//    let roomType: RoomType
     @EnvironmentObject var viewModel: JoinRoomViewModel
     
     var body: some View {
@@ -155,6 +151,7 @@ struct MemberListItemView: View {
             bottomSheetType: .nonDragBar
         ))
     }
+    
 }
 
 struct BottomSheetContentView: View {
@@ -220,7 +217,3 @@ struct BottomSheetContentView: View {
     }
     
 }
-
-//#Preview {
-//    AfterJoinRoomView(roomName: "ㄴㄴㄴ", joinCode: "~~~~~~~~~", memberCount: 1, memberListModel: [JoinMemberModel(memberName: "하세요2"), JoinMemberModel(memberName: "하세요1"), JoinMemberModel(memberName: "하세요"), JoinMemberModel(memberName: "하세요"),JoinMemberModel(memberName: "하세요4")], roomType: .owner)
-//}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomView.swift
@@ -9,11 +9,7 @@ import SwiftUI
 
 struct BeforeJoinRoomView: View {
     @Environment(\.dismiss) private var dismiss
-    @State var roomName: String
-    @State var joinCode: String
-    @State var memberCount: Int
-    @State var memberListModel: [JoinMemberModel]
-    @State var isLoading: Bool = false
+    @StateObject var viewModel: JoinRoomViewModel
     
     var body: some View {
         NavigationStack {
@@ -36,7 +32,7 @@ struct BeforeJoinRoomView: View {
         }
         .overlay(
             Group {
-                if isLoading {
+                if viewModel.isLoading {
                     YMLoadingView(titleText: "방 만드는 중..")
                 }
             }
@@ -69,12 +65,14 @@ struct BeforeJoinRoomView: View {
         }
     }
     
+    //TODO:
     private var bottomView: some View {
-        BeforeJoinRoomBottomView(memberCount: $memberCount, memberListModel: $memberListModel, isLoading: $isLoading)
+        BeforeJoinRoomBottomView()
+            .environmentObject(viewModel)
     }
 }
 
-#Preview {
-    BeforeJoinRoomView(roomName: "ㄴㄴㄴ", joinCode: "~~~~~~~~~", memberCount: 1, memberListModel: [JoinMemberModel(memberName: "하세요2"), JoinMemberModel(memberName: "하세요1"), JoinMemberModel(memberName: "하세요"), JoinMemberModel(memberName: "하세요"),JoinMemberModel(memberName: "하세요4")])
-}
+//#Preview {
+//    BeforeJoinRoomView(roomName: "ㄴㄴㄴ", joinCode: "~~~~~~~~~", memberCount: 1, memberListModel: [JoinMemberModel(memberName: "하세요2"), JoinMemberModel(memberName: "하세요1"), JoinMemberModel(memberName: "하세요"), JoinMemberModel(memberName: "하세요"),JoinMemberModel(memberName: "하세요4")])
+//}
 

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct BeforeJoinRoomView: View {
+    
     @Environment(\.dismiss) private var dismiss
     @StateObject var viewModel: JoinRoomViewModel
     
@@ -65,14 +66,9 @@ struct BeforeJoinRoomView: View {
         }
     }
     
-    //TODO:
     private var bottomView: some View {
         BeforeJoinRoomBottomView()
             .environmentObject(viewModel)
     }
+    
 }
-
-//#Preview {
-//    BeforeJoinRoomView(roomName: "ㄴㄴㄴ", joinCode: "~~~~~~~~~", memberCount: 1, memberListModel: [JoinMemberModel(memberName: "하세요2"), JoinMemberModel(memberName: "하세요1"), JoinMemberModel(memberName: "하세요"), JoinMemberModel(memberName: "하세요"),JoinMemberModel(memberName: "하세요4")])
-//}
-

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  BeforeJoinRoomViewModel.swift
-//  TheGreatestYourManito-iOS
-//
-//  Created by 박신영 on 11/27/24.
-//
-
-import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/BeforeJoinRoomViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  BeforeJoinRoomViewModel.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import Foundation

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
@@ -13,10 +13,11 @@ final class JoinRoomViewModel: ObservableObject {
 //    @Published var cheerText: String = ""
 //    @Published var isNextScreenActive: Bool = false
     
-    @Published var roomName: String
-    @Published var joinCode: String
-    @Published var memberCount: Int
-    @Published var memberListModel: [JoinMemberModel]
+    @Published var roomType: RoomType
+    @Published var roomName: String = ""
+//    @Published var joinCode: String
+    @Published var memberCount: Int = 0
+    @Published var memberListModel: [JoinMemberModel] = []
     @Published var isLoading: Bool = false
     
 //    let receiverUserName: String
@@ -25,9 +26,13 @@ final class JoinRoomViewModel: ObservableObject {
 //    let manittoEndDate: Date
 //    var todaysCheeringCount: Int = 0
     
-    init(roomName: String, joinCode: String, memberCount: Int, memberListModel: [JoinMemberModel], isLoading: Bool) {
+    init(roomType: RoomType) {
+        self.roomType = roomType
+    }
+    
+    init(roomType: RoomType, roomName: String, memberCount: Int, memberListModel: [JoinMemberModel], isLoading: Bool) {
+        self.roomType = roomType
         self.roomName = roomName
-        self.joinCode = joinCode
         self.memberCount = memberCount
         self.memberListModel = memberListModel
         self.isLoading = isLoading

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
@@ -9,22 +9,11 @@ import SwiftUI
 
 final class JoinRoomViewModel: ObservableObject {
     
-//    @Published var cheerType: CheerType?
-//    @Published var cheerText: String = ""
-//    @Published var isNextScreenActive: Bool = false
-    
     @Published var roomType: RoomType
     @Published var roomName: String = ""
-//    @Published var joinCode: String
     @Published var memberCount: Int = 0
     @Published var memberListModel: [JoinMemberModel] = []
     @Published var isLoading: Bool = false
-    
-//    let receiverUserName: String
-//    let receiverUserId: Int
-//    let manittoRoomName: String
-//    let manittoEndDate: Date
-//    var todaysCheeringCount: Int = 0
     
     init(roomType: RoomType) {
         self.roomType = roomType
@@ -38,15 +27,4 @@ final class JoinRoomViewModel: ObservableObject {
         self.isLoading = isLoading
     }
     
-//    func selectCheerType(_ cheerType: CheerType) {
-//        self.cheerType = cheerType
-//        let result = getCheerText(with: cheerType)
-//        self.cheerText = result
-//    }
-//    
-//    func tapSendButton() {
-//        guard let cheerType else { return }
-//        let result = postCheer(with: cheerType, text: cheerText)
-//        if result { isNextScreenActive = true }
-//    }
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/JoinRoomViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  BeforeJoinRoomViewModel.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/27/24.
+//
+
+import SwiftUI
+
+final class JoinRoomViewModel: ObservableObject {
+    
+//    @Published var cheerType: CheerType?
+//    @Published var cheerText: String = ""
+//    @Published var isNextScreenActive: Bool = false
+    
+    @Published var roomName: String
+    @Published var joinCode: String
+    @Published var memberCount: Int
+    @Published var memberListModel: [JoinMemberModel]
+    @Published var isLoading: Bool = false
+    
+//    let receiverUserName: String
+//    let receiverUserId: Int
+//    let manittoRoomName: String
+//    let manittoEndDate: Date
+//    var todaysCheeringCount: Int = 0
+    
+    init(roomName: String, joinCode: String, memberCount: Int, memberListModel: [JoinMemberModel], isLoading: Bool) {
+        self.roomName = roomName
+        self.joinCode = joinCode
+        self.memberCount = memberCount
+        self.memberListModel = memberListModel
+        self.isLoading = isLoading
+    }
+    
+//    func selectCheerType(_ cheerType: CheerType) {
+//        self.cheerType = cheerType
+//        let result = getCheerText(with: cheerType)
+//        self.cheerText = result
+//    }
+//    
+//    func tapSendButton() {
+//        guard let cheerType else { return }
+//        let result = postCheer(with: cheerType, text: cheerText)
+//        if result { isNextScreenActive = true }
+//    }
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/SubViews/BeforeJoinRoomBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/SubViews/BeforeJoinRoomBottomView.swift
@@ -10,13 +10,8 @@ import SwiftUI
 struct BeforeJoinRoomBottomView: View {
     
     @EnvironmentObject var viewModel: JoinRoomViewModel
-//    @Binding var memberCount: Int
-//    @Binding var memberListModel: [JoinMemberModel]
-//    @State private var showDeleteSheet = false
-//    @State private var showSheet = false
     @State private var joinCode: String = ""
-    @State private var navigateToAfterJoinRoom = false //유지
-//    @Binding var isLoading: Bool
+    @State private var navigateToAfterJoinRoom = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -27,13 +22,11 @@ struct BeforeJoinRoomBottomView: View {
             .padding(.top, 48)
             
             VStack {
-                //TODO: joinCode가 다음 뷰에서 Binding으로 받고있어서 이렇게 못 넘긴다.
                 YMTextField(placeholder: "참여코드", text: $joinCode)
                     .padding(.horizontal, 16)
                 Spacer(minLength: 20)
                 
                 // 버튼 클릭 시 navigateToAfterJoinRoom 상태 변경
-                
                 confirmButton()
                     .padding(.horizontal, 16)
             }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/SubViews/BeforeJoinRoomBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/BeforeJoinRoom/SubViews/BeforeJoinRoomBottomView.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct BeforeJoinRoomBottomView: View {
-    @Binding var memberCount: Int
-    @Binding var memberListModel: [JoinMemberModel]
-    @State private var showDeleteSheet = false
-    @State private var showSheet = false
+    
+    @EnvironmentObject var viewModel: JoinRoomViewModel
+//    @Binding var memberCount: Int
+//    @Binding var memberListModel: [JoinMemberModel]
+//    @State private var showDeleteSheet = false
+//    @State private var showSheet = false
     @State private var joinCode: String = ""
-    @State private var navigateToAfterJoinRoom = false
-    @Binding var isLoading: Bool
+    @State private var navigateToAfterJoinRoom = false //유지
+//    @Binding var isLoading: Bool
     
     var body: some View {
         VStack(spacing: 0) {
@@ -25,7 +27,8 @@ struct BeforeJoinRoomBottomView: View {
             .padding(.top, 48)
             
             VStack {
-                YMTextField(placeholder: "방 코드를 입력하세요", text: $joinCode)
+                //TODO: joinCode가 다음 뷰에서 Binding으로 받고있어서 이렇게 못 넘긴다.
+                YMTextField(placeholder: "참여코드", text: $joinCode)
                     .padding(.horizontal, 16)
                 Spacer(minLength: 20)
                 
@@ -41,17 +44,10 @@ struct BeforeJoinRoomBottomView: View {
         .padding(.bottom, 25)
         .navigationDestination(isPresented: $navigateToAfterJoinRoom) {
             AfterJoinRoomView(
-                roomName: "api 통신 결과",
-                memberCount: 4,
-                memberListModel: [
-                    JoinMemberModel(memberName: "psy"),
-                    JoinMemberModel(memberName: "PSY"),
-                    JoinMemberModel(memberName: "박신영"),
-                    JoinMemberModel(memberName: "신영박")
-                ],
-                joinCode: $joinCode,
-                roomType: .owner
+                viewModel: _viewModel,
+                joinCode: $joinCode
             )
+            .environmentObject(viewModel)
         }
         
         
@@ -72,11 +68,11 @@ struct BeforeJoinRoomBottomView: View {
     @ViewBuilder
     private func confirmButton() -> some View {
         YMButton(title: "확인", buttonType: .confirm) {
-            isLoading = true // 로딩 상태 활성화
+            viewModel.isLoading = true // 로딩 상태 활성화
             
             // 5초 후에 로딩 해제 및 화면 전환 수행
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
-                isLoading = false
+                viewModel.isLoading = false
                 navigateToAfterJoinRoom = true
             }
         }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroView.swift
@@ -21,10 +21,14 @@ struct IntroView: View {
                 
                 Spacer()
                 
-                NavigationLink(destination:
-                                // isIdentified가 true면 이미 등록된 기기
-                               // 따라서 true인 곳에 CreateRoom 붙이면 됨!
-                               viewModel.isIdentified ?  SignUpView() : SignUpView(), tag: 1, selection: self.$tag) {
+                NavigationLink(
+                    destination:
+                        // isIdentified가 true면 이미 등록된 기기
+                    // 따라서 true인 곳에 CreateRoom 붙이면 됨!
+                    viewModel.isIdentified ?  SignUpView(viewModel: SignUpViewModel()) : SignUpView(viewModel: SignUpViewModel()),
+                    tag: 1,
+                    selection: self.$tag
+                ) {
                     YMButton(title: "시작하기", buttonType: .confirm, action: {self.tag = 1})
                         .padding(.bottom, 20)
                 }
@@ -35,9 +39,4 @@ struct IntroView: View {
         }
         .padding(.horizontal, 16)
     }
-}
-
-
-#Preview {
-//    IntroView()
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct IntroView: View {
     @State private var tag:Int? = nil
+    @StateObject var viewModel: IntroViewModel
+    
     var body: some View {
         NavigationStack {
             VStack {
@@ -19,10 +21,16 @@ struct IntroView: View {
                 
                 Spacer()
                 
-                NavigationLink(destination: SignUpView(), tag: 1, selection: self.$tag) {
+                NavigationLink(destination:
+                                // isIdentified가 true면 이미 등록된 기기
+                               // 따라서 true인 곳에 CreateRoom 붙이면 됨!
+                               viewModel.isIdentified ?  SignUpView() : SignUpView(), tag: 1, selection: self.$tag) {
                     YMButton(title: "시작하기", buttonType: .confirm, action: {self.tag = 1})
                         .padding(.bottom, 20)
                 }
+                               .onAppear {
+                                   viewModel.postUserIdentify()
+                               }
             }
         }
         .padding(.horizontal, 16)
@@ -31,5 +39,5 @@ struct IntroView: View {
 
 
 #Preview {
-    IntroView()
+//    IntroView()
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
@@ -19,8 +19,8 @@ final class IntroViewModel: ObservableObject {
         let device = Device()
         _ = device.getDeviceUUID()
         guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}
+        let requestBody = UserIdentifyRequestBody(deviceId: deviceId)
         
-        let requestBody = UserIdentifyRequestBody(deviceId: "7777")
         NetworkService.shared.userService.postUserIdentify(
             requestBody: requestBody,
             completion: { result in

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  IntroViewModel.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/28/24.
+//
+
+import SwiftUI
+
+final class IntroViewModel: ObservableObject {
+    
+    @Published var isIdentified: Bool
+    
+    init(isIdentified: Bool) {
+        self.isIdentified = isIdentified
+    }
+    
+    func postUserIdentify() {
+        let device = Device()
+        _ = device.getDeviceUUID()
+        guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}
+        
+        let requestBody = UserIdentifyRequestBody(deviceId: "7777")
+        NetworkService.shared.userService.postUserIdentify(
+            requestBody: requestBody,
+            completion: { result in
+            switch result {
+            case .success(let response):
+                print("Success: \(response)")
+                self.isIdentified = true
+                print("isIdentified : \(self.isIdentified)")
+            case .requestErr:
+                self.isIdentified = false
+                print("isIdentified : \(self.isIdentified)")
+            default:
+                print("Failed to another reason")
+                return
+            }
+        })
+    }
+    
+}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SignUpView: View {
+    @StateObject var viewModel: SignUpViewModel
     @State private var nickname: String = ""
     var body: some View {
         VStack(alignment: .leading) {
@@ -24,8 +25,10 @@ struct SignUpView: View {
             .padding(.top, 56)
             
             Spacer()
-            YMButton(title: "확인", buttonType: .confirm, action: {print("닉네임: \(nickname)")})
-                .padding(.bottom, 20)
+            YMButton(title: "확인",
+                     buttonType: .confirm,
+                     action: {viewModel.postMakeUser(nickname: nickname)})
+                    .padding(.bottom, 20)
             
         }
 //        .padding(.horizontal, 16)
@@ -33,6 +36,6 @@ struct SignUpView: View {
     }
 }
 
-#Preview {
-    SignUpView()
-}
+//#Preview {
+//    SignUpView()
+//}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
@@ -31,11 +31,6 @@ struct SignUpView: View {
                     .padding(.bottom, 20)
             
         }
-//        .padding(.horizontal, 16)
         .navigationBarBackButtonHidden()
     }
 }
-
-//#Preview {
-//    SignUpView()
-//}

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
@@ -25,10 +25,15 @@ struct SignUpView: View {
             .padding(.top, 56)
             
             Spacer()
-            YMButton(title: "확인",
-                     buttonType: .confirm,
-                     action: {viewModel.postMakeUser(nickname: nickname)})
-                    .padding(.bottom, 20)
+            YMButton(
+                title: "확인",
+                buttonType: .confirm,
+                action: {
+                    viewModel.postMakeUser(nickname: nickname)
+                    // 메인뷰로 화면 전환 좀
+                }
+            )
+            .padding(.bottom, 20)
             
         }
         .navigationBarBackButtonHidden()

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  SignUpViewModel.swift
+//  TheGreatestYourManito-iOS
+//
+//  Created by 박신영 on 11/28/24.
+//
+
+import SwiftUI
+
+final class SignUpViewModel: ObservableObject {
+    
+    func postMakeUser(nickname: String) {
+        guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}
+        let requestBody = MakeUserRequestBody(nickname: nickname, deviceId: deviceId)
+        
+        NetworkService.shared.userService.postMakeUser(requestBody: requestBody, completion: { result in
+            switch result {
+            case .success(let response):
+                print("Success: \(response)")
+                UserDefaults.standard.set(response.result?.userCode, forKey: "userCode")
+                print(UserDefaults.standard.string(forKey: "userCode") ?? "")
+            default:
+                print("Failed to another reason")
+                return
+            }
+        })
+    }
+    
+}
+


### PR DESCRIPTION
## 📌 What is the PR?

- JoinRoom(Before, After) ViewModel을 적용합니다.
- Network User 파트 구현 및 일부 API 연결

## 🪄 Changes

<!-- 작업 내용을 리스트로 작성해주세요. -->
## 🚨 이슈 요약
<!-- 이슈에 대한 내용을 간략하게 기술합니다 -->


## ✅ 체크 리스트
<!-- 체크 리스트 타입으로 할 일을 분류합니다 -->
- [x] BeforeJoinRoom ViewModel 적용
- [x] AfterJoinRoom ViewModel 적용
- [x] Network User 구현
- [x] postMakeUser() api 연결
- [x] postUserIdentify() api 연결
- [x] IntroViewmodel, SignUpViewModel 구현

## 🌐 Common Changes

<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->
```
struct Device {
    
    func getDeviceUUID() -> String {
        let deviceId = UIDevice.current.identifierForVendor!.uuidString
        UserDefaults.standard.set(deviceId, forKey: "deviceId")
        return deviceId
    }
    
}
```
- 어플 시작 시 Device getDeviceUUID() 함수가 실행되기에 추후 다른 뷰에서 `deviceId`를 사용해야 할 때에는 아래와 같이 선언하여 사용하면 됩니다!
  - `guard let deviceId = UserDefaults.standard.string(forKey: "deviceId") else {return}`
- 더불어 api 통신할 때에 필요한 userCode 역시 아래와 같이 선언 이후 사용하시면 됩니다!
  - `guard let userCode = UserDefaults.standard.string(forKey: "userCode") else {return}`
- Development.xcconfig 파일 중 BaseURL 파트 수정된 부분이 있으니 공지 확인해주세요!

## 🙆🏻 To Reviewers

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- Network 폴더링 방식은 postman 기준 BaseURL 바로 뒤에 위치한 값을 기준으로 api 관련 함수들을 나누었습니다.
- Network 속 User 폴더를 참고하여 다른 Network 관련 코드 작성 해주시면 돼요.

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #30 
