### PR TITLE
[Fix] QA (#56)

### DIFF
--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/ManittoEventStatus.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Application/Model/ManittoEventStatus.swift
@@ -29,7 +29,6 @@ enum ManittoEventStatus {
     
     var labelString: String {
         switch self {
-            
         case .ongoing(dDay: let dDay):
             return dDay == 0 ? "D-Day" : "D-\(dDay)"
         case .ended:
@@ -37,32 +36,67 @@ enum ManittoEventStatus {
         }
     }
     
-    /// 날짜를 비교하여 EventStatus 반환
-    static func getStatus(from eventDate: Date) -> Self {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        let eventDay = calendar.startOfDay(for: eventDate)
+    // 버튼 제목
+    var buttonTitle: String {
+        switch self {
+        case .ongoing:
+            return "보내기" // 이벤트가 진행 중일 때의 버튼 제목
+        case .ended:
+            return "결과보기" // 이벤트가 종료되었을 때의 버튼 제목
+        }
+    }
+    
+    // 버튼 액션
+    var buttonAction: () -> Void {
+        switch self {
+        case .ongoing:
+            return {
+                // 진행 중인 이벤트의 버튼 액션
+                print("진행 중 이벤트")
+            }
+        case .ended:
+            return {
+                // 종료된 이벤트의 버튼 액션
+                print("종료된 이벤트")
+            }
+        }
+    }
+    
+    static func getStatus(from isoDateString: String) -> Self {
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds] // ISO8601의 YYYY-MM-DDTHH:mm:ssZ 형식
         
-        if let dDay = calendar.dateComponents([.day], from: today, to: eventDay).day {
+        guard let utcDate = isoFormatter.date(from: isoDateString) else {
+            return .ended // 유효하지 않은 날짜일 경우 종료 상태 반환
+        }
+        
+        // 로컬 타임존으로 변환
+        let localCalendar = Calendar.current
+        let localEventDate = localCalendar.startOfDay(for: utcDate) // UTC를 로컬 타임존 기준으로 변환
+        let localToday = localCalendar.startOfDay(for: Date()) // 로컬 타임존의 오늘
+        
+        if let dDay = localCalendar.dateComponents([.day], from: localToday, to: localEventDate).day {
             if dDay < 0 {
                 return .ended
+            } else if dDay == 0 {
+                // 오늘 날짜이고, 시간이 지나면 종료 상태로 설정
+                let localEventHour = localCalendar.component(.hour, from: utcDate)
+                let localEventMinute = localCalendar.component(.minute, from: utcDate)
+                
+                let localNow = Date()
+                let currentHour = localCalendar.component(.hour, from: localNow)
+                let currentMinute = localCalendar.component(.minute, from: localNow)
+                
+                if currentHour > localEventHour || (currentHour == localEventHour && currentMinute > localEventMinute) {
+                    return .ended
+                } else {
+                    return .ongoing(dDay: 0)
+                }
             } else {
                 return .ongoing(dDay: dDay)
             }
         }
         
         return .ended
-    }
-    
-    /// ISO8601 String -> EventStatus 반환
-    static func getStatus(from isoDateString: String) -> Self {
-        let isoFormatter = ISO8601DateFormatter()
-        isoFormatter.formatOptions = [.withFullDate] // ISO8601의 YYYY-MM-DD 형식
-        
-        guard let eventDate = isoFormatter.date(from: isoDateString) else {
-            return .ended // 유효하지 않은 날짜일 경우 종료 상태 반환
-        }
-        
-        return getStatus(from: eventDate)
     }
 }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Literal/StringLiterals.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Global/Literal/StringLiterals.swift
@@ -9,6 +9,10 @@ import SwiftUI
 
 enum StringLiterals {
     
+    enum ToastMessage {
+        static let nicknamePlaceholderLabel = "한글, 영문 1자 이상, 7자 이하"
+    }
+    
     enum AfterJoinRoom {
         static let ownerNoticeWordLabel = "참여자가 다 모이면 확인 버튼을 눌러주세요!"
         static let notOwnerNoticeWordLabel = "참여자를 기다리고있어요~"

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseService.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/BaseService.swift
@@ -9,17 +9,19 @@ import Foundation
 
 class BaseService {
     func judgeStatus<T: Decodable>(statusCode: Int, data: Data) -> NetworkResult<T> {
-      switch statusCode {
-      case 200..<205:
-         return isValidData(data: data, responseType: T.self)
-      case 400..<500:
-         return .requestErr
-      case 500:
-         return .serverErr
-      default:
-         return .networkFail
-      }
-   }
+        switch statusCode {
+        case 200..<205:
+            return isValidData(data: data, responseType: T.self)
+        case 400..<500:
+            let decoder = JSONDecoder()
+            let errorResponse = try? decoder.decode(T.self, from: data)
+            return .requestErr(errorResponse as T?)
+        case 500:
+            return .serverErr
+        default:
+            return .networkFail
+        }
+    }
    
     func isValidData<T: Decodable>(data: Data, responseType: T.Type) -> NetworkResult<T> {
       let decoder = JSONDecoder()

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkResult.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkResult.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum NetworkResult<T> {
    case success(T)               // 서버 통신 성공했을 때,
-   case requestErr               // 요청 에러 발생했을 때,
+   case requestErr(T?)               // 요청 에러 발생했을 때,
    case decodedErr               // 디코딩 오류 발생했을 때
    case pathErr                  // 경로 에러 발생했을 때,
    case serverErr                // 서버의 내부적 에러가 발생했을 때,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkResult.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Base/NetworkResult.swift
@@ -9,7 +9,6 @@ import Foundation
 
 enum NetworkResult<T> {
    case success(T)               // 서버 통신 성공했을 때,
-   case tokenExpired(T)             // 토큰 만료일 떄,
    case requestErr               // 요청 에러 발생했을 때,
    case decodedErr               // 디코딩 오류 발생했을 때
    case pathErr                  // 경로 에러 발생했을 때,

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/ResponseDTO/GetManittoResultResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/ResponseDTO/GetManittoResultResponseBody.swift
@@ -10,60 +10,77 @@ import Foundation
 // MARK: - GetManittoResultResponseBody
 struct GetManittoResultResponseBody: Codable {
     let manitto: Manitto
-    let cheerCounts: [CheerCount]
+    let cheerCounts: CheerCounts // CheerCounts의 타입을 맞추기 위해 수정
     let manittoRank: [ManittoRank]
 }
 
-// MARK: - CheerCount
-struct CheerCount: Codable {
-    let type: String
-    let count: Int
+// MARK: - CheerCounts
+struct CheerCounts: Codable {
+    let luck, love, fire, present: Int
 }
-
-typealias CheerCounts = [CheerCount]
 
 extension CheerCounts {
     func toCheerCountDic() -> [CheerType: Int] {
-        self.compactMap { cheerCount -> (CheerType, Int)? in
-            if let cheerType = CheerType(name: cheerCount.type) {
-                return (cheerType, cheerCount.count)
-            } else {
-                return nil
-            }
-        }.reduce(into: [CheerType: Int]()) { result, pair in
-            result[pair.0] = pair.1
-        }
+        [
+            .luck: luck,
+            .love: love,
+            .fire: fire,
+            .gift: present
+        ]
     }
 }
 
 // MARK: - Manitto
 struct Manitto: Codable {
     let userName: String
-    let userId: Int
+    let userID: Int
+
+    enum CodingKeys: String, CodingKey {
+        case userName
+        case userID = "userId"
+    }
 }
 
 // MARK: - ManittoRank
 struct ManittoRank: Codable {
-    let rank, userId: Int
+    let rank, userID: Int
     let userName: String
-    let manittoUserId: Int
+    let manittoUserID: Int
     let manittoUserName: String
     let cheerCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case rank
+        case userID = "userId"
+        case userName
+        case manittoUserID = "manittoUserId"
+        case manittoUserName, cheerCount
+    }
 }
+
 
 typealias ManittoRanks = [ManittoRank]
 
 extension ManittoRanks {
     func toManittoRankList() -> ManittoRankList {
-        self.compactMap { item in
-            guard let rank = ManiitoRank(rank: item.rank) else { return nil }
-            return ManittoRankItem(
-                rank: rank,
-                fromPerson: User(id: item.manittoUserId, name: item.manittoUserName),
-                toPerson: User(id: item.userId, name: item.userName),
-                cheerCount: item.cheerCount
-            )
-        }
+        return self
+            .map { item -> ManittoRankItem? in
+                // rank 변환 실패 시 nil 반환
+                guard let rank = ManiitoRank(rank: item.rank) else {
+                    return nil
+                }
+                
+                // rank 변환 성공 시 ManittoRankItem 반환
+                return ManittoRankItem(
+                    rank: rank,
+                    fromPerson: User(id: item.userID, name: item.userName),
+                    toPerson: User(id: item.manittoUserID, name: item.manittoUserName),
+                    cheerCount: item.cheerCount
+                )
+            }
+            .compactMap { $0 }  // nil을 필터링하여 제거
     }
 }
+
+
 

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/ResponseDTO/GetManittoResultResponseBody.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Network/Room/ResponseDTO/GetManittoResultResponseBody.swift
@@ -64,7 +64,7 @@ typealias ManittoRanks = [ManittoRank]
 extension ManittoRanks {
     func toManittoRankList() -> ManittoRankList {
         return self
-            .map { item -> ManittoRankItem? in
+            .compactMap { item -> ManittoRankItem? in
                 // rank 변환 실패 시 nil 반환
                 guard let rank = ManiitoRank(rank: item.rank) else {
                     return nil
@@ -78,7 +78,6 @@ extension ManittoRanks {
                     cheerCount: item.cheerCount
                 )
             }
-            .compactMap { $0 }  // nil을 필터링하여 제거
     }
 }
 

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Components/YMJoinCodeStackView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Components/YMJoinCodeStackView.swift
@@ -74,7 +74,10 @@ struct CopyToastView: View {
         .padding()
         .frame(maxWidth: .infinity)
         .background(.gray3)
+        .border(.ymPrimary, width: 1)
         .clipShape(.rect(cornerRadius: 16))
+        .overlay(RoundedRectangle(cornerRadius: 16)
+            .stroke(.sub1, lineWidth: 2))
         
     }
     

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomView.swift
@@ -57,14 +57,15 @@ struct CreateRoomView: View {
                 .datePickerStyle(GraphicalDatePickerStyle())
                 
                 
-                YMButton(title: "확인", buttonType: .confirm, action: { 
-                    if viewModel.selectedDate == nil {
-                        viewModel.selectedDate = Date() // 기본값 설정
-                    }
-                    viewModel.calculateDday(date: viewModel.selectedDate)
-                    isDatePickerPresented = false
-                })
-                .padding(.horizontal, 16)
+                YMButton(title: "확인",
+                         buttonType: .confirm,
+                         action: {
+                            if viewModel.selectedDate == nil {
+                                viewModel.selectedDate = Date() // 기본값 설정
+                            }
+                        viewModel.calculateDday(date: viewModel.selectedDate)
+                        isDatePickerPresented = false})
+                    .padding(.horizontal, 16)
             }
             .presentationDetents([.fraction(0.6)])
         }
@@ -197,6 +198,7 @@ struct CreateRoomView: View {
                     YMButton(
                         title: "확인",
                         buttonType: .confirm,
+                        isEnabled: viewModel.isEnabled,
                         action: {
                             viewModel.createButtonTapped()
                         }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomView.swift
@@ -60,12 +60,10 @@ struct CreateRoomView: View {
                 YMButton(title: "확인",
                          buttonType: .confirm,
                          action: {
-                            if viewModel.selectedDate == nil {
-                                viewModel.selectedDate = Date() // 기본값 설정
-                            }
-                        viewModel.calculateDday(date: viewModel.selectedDate)
-                        isDatePickerPresented = false})
-                    .padding(.horizontal, 16)
+                            viewModel.tappedConfirmButton()
+                            isDatePickerPresented = false
+                })
+                .padding(.horizontal, 16)
             }
             .presentationDetents([.fraction(0.6)])
         }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomViewModel.swift
@@ -8,9 +8,21 @@
 import SwiftUI
 
 final class CreateRoomViewModel: ObservableObject {
-    @Published var roomName: String = ""
-    @Published var selectedDate: Date? = nil
-    @Published var selectedTime: Date? = nil
+    @Published var roomName: String = "" {
+        didSet {
+            isAllVailed()
+        }
+    }
+    @Published var selectedDate: Date? = nil {
+        didSet {
+            isAllVailed()
+        }
+    }
+    @Published var selectedTime: Date? = nil {
+        didSet {
+            isAllVailed()
+        }
+    }
     @Published var endDateTime: Date? = nil
     @Published var roomId: Int = 0
     @Published var joinCode: String = ""
@@ -18,6 +30,7 @@ final class CreateRoomViewModel: ObservableObject {
     @Published var isSuccessCreateRoom: Bool = false
     @Published var toastText: String = ""
     @Published var showToast: Bool = false
+    @Published var isEnabled: Bool = false
     
     func updateDateTime(date: Date?, time: Date?) throws {
         guard let date = selectedDate, let time = selectedTime else {
@@ -43,6 +56,14 @@ final class CreateRoomViewModel: ObservableObject {
         
         // 날짜 차이를 계산
         dDay = calendar.dateComponents([.day], from: today, to: targetDate).day ?? 0
+    }
+    
+    func isAllVailed() {
+        if !roomName.isEmpty && roomName.count <= UserInputPolicy.roomNameMaxLength && selectedDate != nil && selectedTime != nil {
+            self.isEnabled = true
+        } else {
+            self.isEnabled = false
+        }
     }
     
     func createButtonTapped() {

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/CreateRoom/CreateRoomViewModel.swift
@@ -49,10 +49,11 @@ final class CreateRoomViewModel: ObservableObject {
         endDateTime = calendar.date(from: combinedComponents)
     }
     
-    func calculateDday(date: Date?) {
+    func tappedConfirmButton() {
+        selectedDate = Date() // 기본값 설정
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date()) // 오늘의 날짜를 00:00으로 설정
-        let targetDate = calendar.startOfDay(for: date ?? Date()) // 선택된 날짜를 00:00으로 설정
+        let targetDate = calendar.startOfDay(for: selectedDate ?? Date()) // 선택된 날짜를 00:00으로 설정
         
         // 날짜 차이를 계산
         dDay = calendar.dateComponents([.day], from: today, to: targetDate).day ?? 0

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Intro/IntroViewModel.swift
@@ -38,9 +38,11 @@ final class IntroViewModel: ObservableObject {
                         LocalStorageManager.saveUserId(userId)
                     }
                     toastPost("로그인에 성공했습니다.")
-                case .requestErr:
+                case .requestErr(let errorResponse):
                     self.isIdentified = false
-                    toastPost("서버 에러가 발생했습니다.\n다시 시도해주세요.")
+                    if errorResponse?.message != "해당 유저를 찾을 수 없습니다." {
+                        toastPost("서버 에러가 발생했습니다.\n다시 시도해주세요.")
+                    }
                 default:
                     toastPost("알 수 없는 오류가 발생했습니다.\n다시 시도해주세요.")
                     return

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardView.swift
@@ -75,15 +75,6 @@ private extension ManittoResultBoardView {
                     .foregroundStyle(.gray1)
             }
             Spacer()
-            Button(action: {}, label: {
-                Text(StringLiterals.PlayManittoResultBoard.boardShowDetailStr)
-                    .font(.pretendardFont(for: .heading6))
-                    .foregroundStyle(.gray1)
-                    .padding(.horizontal, 13)
-                    .padding(.vertical, 8)
-                    .background(Color.gray3)
-                    .clipShape(.rect(cornerRadius: 16))
-            })
         }
     }
     

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardView.swift
@@ -27,7 +27,8 @@ struct ManittoResultBoardView: View {
             
             Spacer()
             
-            ManittoResultBoardBottomView(viewModel)
+            ManittoResultBoardBottomView()
+                .environmentObject(viewModel)
                 .frame(height: 423)
                 .cornerRadius(40, corners: [.topLeft, .topRight])
                 .shadow(radius: 10)

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/ManittoResultBoardViewModel.swift
@@ -48,6 +48,7 @@ private extension ManittoResultBoardViewModel {
                 self?.manittoName = result.manitto.userName
                 self?.cheerCounts = result.cheerCounts.toCheerCountDic()
                 self?.manittoRankList =  result.manittoRank.toManittoRankList()
+                print("🔥\n\(self?.manittoRankList)")
                 
             default:
 #if DEBUG

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/SubView/ManittoResultBoardBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/ManittoResultBoard/SubView/ManittoResultBoardBottomView.swift
@@ -8,11 +8,7 @@
 import SwiftUI
 
 struct ManittoResultBoardBottomView: View {
-    var viewModel: ManittoResultBoardViewModel
-    
-    init(_ viewModel: ManittoResultBoardViewModel) {
-        self.viewModel = viewModel
-    }
+    @EnvironmentObject var viewModel: ManittoResultBoardViewModel
     
     var body: some View {
         

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/PlayManittoViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/PlayManittoViewModel.swift
@@ -54,7 +54,15 @@ final class PlayManittoViewModel: ObservableObject {
         getCheerText(with: cheerType)
     }
     
-    func tapSendButton() {
+    func isEndedStatus(status: ManittoEventStatus) {
+        if case .ongoing = status {
+            self.tapSendButton()  // 진행 중일 때의 액션
+        } else if case .ended = status {
+            self.isEnded = true
+        }
+    }
+    
+    private func tapSendButton() {
         guard let cheerType else {
             toastPost("응원 타입을 선택해주세요.")
             return
@@ -77,6 +85,7 @@ final class PlayManittoViewModel: ObservableObject {
             }
         }
     }
+    
 }
 
 // MARK: API

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/PlayManittoViewModel.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/PlayManittoViewModel.swift
@@ -17,6 +17,7 @@ final class PlayManittoViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var receiverUserName: String = ""
     @Published var receiverUserId: Int = 0
+    @Published var isEnded: Bool = false
     
     let manittoRoomName: String
     let manittoRoomId: Int

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/SubView/PlayManittoBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/SubView/PlayManittoBottomView.swift
@@ -31,11 +31,7 @@ struct PlayManittoBottomView: View {
                     buttonType: .confirm,
                     action: {
                         // 상태에 맞는 행동을 viewModel에서 처리하도록 함
-                        if case .ongoing = status {
-                            viewModel.tapSendButton()  // 진행 중일 때의 액션
-                        } else if case .ended = status {
-                            viewModel.isEnded = true
-                        }
+                        viewModel.isEndedStatus(status: status)
                     }
                 )
             }

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/SubView/PlayManittoBottomView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/Participate/PlayManitto/SubView/PlayManittoBottomView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct PlayManittoBottomView: View {
-    
     @EnvironmentObject var viewModel: PlayManittoViewModel
     
     var body: some View {
+        let status = ManittoEventStatus.getStatus(from: viewModel.manittoEndDate)
         VStack {
             VStack(alignment: .leading, spacing: 24) {
                 cheerLabelView()
@@ -26,15 +26,28 @@ struct PlayManittoBottomView: View {
             
             VStack(spacing: 20) {
                 OpenLabelView(status: ManittoEventStatus.getStatus(from: viewModel.manittoEndDate))
-                YMButton(title: StringLiterals.PlayManitto.bottomSheetSendButtonStr, buttonType: .confirm, action: {
-                    viewModel.tapSendButton()
-                })
+                YMButton(
+                    title: status.buttonTitle,
+                    buttonType: .confirm,
+                    action: {
+                        // 상태에 맞는 행동을 viewModel에서 처리하도록 함
+                        if case .ongoing = status {
+                            viewModel.tapSendButton()  // 진행 중일 때의 액션
+                        } else if case .ended = status {
+                            viewModel.isEnded = true
+                        }
+                    }
+                )
             }
         }
         .padding(.horizontal, 16)
         .padding(.top, 48)
         .padding(.bottom, 54)
         .background(.ymWhite)
+        .navigationDestination(isPresented: $viewModel.isEnded) {
+            ManittoResultBoardView(viewModel: ManittoResultBoardViewModel(manittoRoomName: viewModel.manittoRoomName, manittoRoomId: viewModel.manittoRoomId))
+                .environmentObject(viewModel)
+        }
     }
 }
 

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
@@ -21,7 +21,7 @@ struct SignUpView: View {
                     .font(.pretendardFont(for: .subtitle1))
                     .foregroundStyle(.gray1)
                     .padding(.leading, 7)
-                YMTextField(placeholder: "한글, 영문 1자 이상, 7자 이하", text: $viewModel.nickname)
+                YMTextField(placeholder: StringLiterals.ToastMessage.nicknamePlaceholderLabel, text: $viewModel.nickname)
             }
             .padding(.top, 56)
             

--- a/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
+++ b/TheGreatestYourManito-iOS/TheGreatestYourManito-iOS/Presentation/SignUp/Views/SignUpView.swift
@@ -21,7 +21,7 @@ struct SignUpView: View {
                     .font(.pretendardFont(for: .subtitle1))
                     .foregroundStyle(.gray1)
                     .padding(.leading, 7)
-                YMTextField(placeholder: "한글, 영문 7자 이하", text: $viewModel.nickname)
+                YMTextField(placeholder: "한글, 영문 1자 이상, 7자 이하", text: $viewModel.nickname)
             }
             .padding(.top, 56)
             
@@ -29,6 +29,7 @@ struct SignUpView: View {
             YMButton(
                 title: "확인",
                 buttonType: .confirm,
+                isEnabled: viewModel.isEnabled,
                 action: {
                     viewModel.confirmButtonTapped()
                 }
@@ -42,7 +43,7 @@ struct SignUpView: View {
                     VStack {
                         Spacer()
                         CopyToastView(textTitle: viewModel.toastText)
-                            .padding(.bottom, 140)
+                            .padding(.bottom, 20)
                             .padding(.horizontal, 16)
                     }
                 }


### PR DESCRIPTION
## 📌 What is the PR?

- 자체 QA를 진행하였습니다.

## 🪄 Changes
- [x] IntroView: IntroViewModel postUserIdentify() 에러 대응
- [x] 공용ToastView overlay 추가
- [x] SignUpView: 닉네임 유효성 검사 및 버튼 활성 로직 추가
- [x] CreateRoomView: '방 생성(확인)' 버튼 활성 로직 추가
- [x] PlayManittoView: endDate 이후 ManittoResultBoardView 이동 로직 추가
- [x] ManittoResultBoardView: 데이터 통신 값에 맞게 모델 변경 및 화면 표시
- [x] ManittoResultBoardView: '자세히 보기' 버튼 삭제

## 🌐 Common Changes
- 공용ToastView overlay 추가하였으니 확인 부탁드려요.
  - 각 ToastView가 사용되는 bottom 위치가 다른 것 같아 이는 조정이 필요해 보입니다.

## 🙆🏻 To Reviewers
### 1. IntroView: IntroViewModel postUserIdentify() 에러 대응

- 문제
    
    ```swift
    NetworkService.shared.userService.postUserIdentify(
          requestBody: requestBody,
          completion: { [weak self] result in
              guard let self else { return }
              // 로딩 해제
              self.isLoading = false
              
              switch result {
                                  
              case .success(let response):
                  self.isIdentified = true
                  if let userId = response.result?.userId {
                      LocalStorageManager.saveUserId(userId)
                  }
                  toastPost("로그인에 성공했습니다.")
              case .requestErr(let errorResponse):
                  self.isIdentified = false
              default:
                  toastPost("알 수 없는 오류가 발생했습니다.\n다시 시도해주세요.")
                  return
              }
          })
    ```
    
    - Intro 접근시 postUserIdentify 함수가 실행돼, 등록되지 않은 UUID라면 등록된 사람이 아닐 때에도 statusCode가 404로 반환되기에 requestErr가 발생하는데 이것도 서버 에러로 반환됩니다.
- 해결
    
    ```swift
    case .requestErr(let errorResponse):
    	self.isIdentified = false
    	if errorResponse?.message != "해당 유저를 찾을 수 없습니다." {
    	    toastPost("서버 에러가 발생했습니다.\n다시 시도해주세요.")
    	}
    ```
    
    - NetworkResult의 requestErr 반환 타입을 `case requestErr(T?)`로 바꾸고 위와 같이 들어오는 message로 분기처리 진행하였습니다.
    - IntroView에서 진행한 postUserIdentify() 에러 대응이 잘 동작하는지 한 번씩 확인 부탁드립니다.

<br>

### 2. 공용: ToastView overlay 추가

- 문제
    - overlay 미적용시 닉네임 작성 중 활성화되는 keyboard와 validateNickname() 함수로 인하여 ToastView의 layout이 하단 버튼과 겹치는 상황이 발생하여 이를 확인할 수 없었습니다.
- 해결
  <img src="https://github.com/user-attachments/assets/a2e2b81f-0641-438d-a288-dcbba9c404ab" height="400" height="50"/>
  - overlay를 적용하여 하단 버튼이 있는 경우에도 ToastMessage의 범위를 직관적으로 알 수 있도록 하였습니다.
  - 추후 ToastView layout 관련 리펙토링이 모두 끝난다면 위와 같은 상황이 발생하지 않기에 해당 기능에 대해 다시 논의해보면 좋을 것 같습니다.

<br>

### 3. SignUpView: 닉네임 유효성 검사 및 버튼 활성 로직 추가 및

- 문제
    
    닉네임이 입력되지 않았거나, 적절한 한글이 아닐 경우에도 `확인 버튼` 활성화가 발생하던 상황
    
- 해결
    
    ```swift
    struct UserInputPolicy {
        static let userNickNameRegex = "^[a-zA-Z가-힣]{1,7}$"
        static let roomNameMaxLength = 20
        
        static func userNickNameIsValid(_ userNickName: String) -> Bool {
            return userNickName.range(of: userNickNameRegex, options: .regularExpression) != nil
        }
    }
    ```
    
    위 UserInputPolicy를 만들어 nickName 관련 정규식과 static func userNickNameIsValid()를 만들어 닉네임의 유효성을 검사하였습니다.
    
<br>

### 4. CreateRoomView: '방 생성(확인)' 버튼 활성 로직 추가

- 문제
    
    방 제목, 종료일, 종료 시간이 입력되지 않아도 `방생성 버튼` 활성화가 발생하던 상황
    
- 해결
    
    ```swift
    func isAllVailed() {
        if !roomName.isEmpty && roomName.count <= UserInputPolicy.roomNameMaxLength && selectedDate != nil && selectedTime != nil {
            self.isEnabled = true
        } else {
            self.isEnabled = false
        }
    }
    
    func createButtonTapped() {
        guard roomName.isEmpty == false else {
            toastPost("방 이름을 입력해주세요.")
            return
        }
        
        guard roomName.count <= UserInputPolicy.roomNameMaxLength else {
            toastPost("방 이름은 최대 20자를 넘을 수 없습니다.")
            return
        }
        
        do {
            try updateDateTime(date: selectedDate, time: selectedTime)
        } catch {
            toastPost("종료 날짜, 종료 시간을 지정해주세요.")
            return
        }
        
        postMakeRoom { [weak self] in
            self?.isSuccessCreateRoom = true
        }
    }
    ```
    - 각각 roomName, selectedDate, selectedTime에 didSet을 적용하여 해당 값들이 바뀐다면 isAllVailed() 함수가 실행되도록 하였고, 이후 isEnabled 값으로 `방생성 버튼`의 활성화 상태처리를 다루었습니다.
    - createButtonTapped() 함수를 사용하여 각 상황에 맞는 Toast 메세지가 표시되도록 대응하였습니다.

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->


## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->

- Resolved: #56 
